### PR TITLE
path fix for aws-cli to make permanent in Centos7

### DIFF
--- a/dks-host/dks-host-install.sh
+++ b/dks-host/dks-host-install.sh
@@ -25,7 +25,8 @@ curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
 unzip awscli-bundle.zip
 sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 sudo /usr/local/bin/python2.7 awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-export PATH=/home/ec2-user/.local/bin:$PATH
+sudo echo "PATH=/usr/local/aws/bin:$PATH" > /etc/profile.d/aws.sh
+sudo chmod +x /etc/profile.d/aws.sh
 
 # Download & install latest DKS service artifact
 URL=`curl -s https://api.github.com/repos/dwp/data-key-service/releases/latest \


### PR DESCRIPTION
sudo echo "PATH=/usr/local/aws/bin:$PATH" > /etc/profile.d/aws.sh
sudo chmod +x /etc/profile.d/aws.sh