### PR TITLE
Install the AWS CloudHSM Client and Command Line Tools

### DIFF
--- a/dks-host/dks-host-install.sh
+++ b/dks-host/dks-host-install.sh
@@ -14,7 +14,7 @@ acm_cert_helper_repo=acm-pca-cert-generator
 acm_cert_helper_version=0.8.0
 
 # Install the AWS CloudHSM Client and Command Line Tools
-sudo yum install -y https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL6/cloudhsm-client-latest.el6.x86_64.rpm
+sudo yum install -y https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm
 
 # pip is not available in CentOS 7 core repositories there is a requirement to enable EPEL repositories prior
 sudo yum --enablerepo=extras install -y epel-release

--- a/dks-host/dks-host-install.sh
+++ b/dks-host/dks-host-install.sh
@@ -13,9 +13,13 @@ sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/late
 acm_cert_helper_repo=acm-pca-cert-generator
 acm_cert_helper_version=0.8.0
 
+# Install the AWS CloudHSM Client and Command Line Tools
+sudo yum install -y https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL6/cloudhsm-client-latest.el6.x86_64.rpm
+
 # pip is not available in CentOS 7 core repositories there is a requirement to enable EPEL repositories prior
 sudo yum --enablerepo=extras install -y epel-release
 sudo yum install -y python-pip
+
 # gcc and python-devel are required to enable the twofish indirect dependency -
 # of acm-pca-cert-generator to be built and installed
 sudo yum install -y gcc


### PR DESCRIPTION
Install the AWS CloudHSM Client and Command Line Tools to EC2 on same subnet to enable connect to a CloudHSM cluster