### PR TITLE
Removed override for Source AMI Name

### DIFF
--- a/dw-general-ami/dw-general-ami-install.sh
+++ b/dw-general-ami/dw-general-ami-install.sh
@@ -18,7 +18,7 @@ yum install -y http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-plugin-r
 
 # Configure YUM repos to point at fixed mirrors so requests through the proxy will work
 # sed -i -e 's/^mirrorlist=/#&/' -e 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
-yum-config-manager --enable epel
+sudo yum-config-manager --enable epel
 sed -i -e 's/^metalink=/#&/' -e 's@^#baseurl=.*@baseurl=http://mirrors.coreix.net/fedora-epel/7/$basearch@' /etc/yum.repos.d/epel.repo
 
 # Install Java

--- a/dw-general-ami/generic_packer_template.json.j2
+++ b/dw-general-ami/generic_packer_template.json.j2
@@ -8,10 +8,10 @@
       "type": "amazon-ebs",
       "source_ami_filter": {
         "filters": {
-          "virtualization-type": "{{ event['source_ami_virt_type'] or 'hvm' }}",
+          "virtualization-type": "hvm",
           "name": "amzn-ami-hvm-*",
-          "root-device-type": "{{ event['source_ami_root_device_type'] or 'ebs'}}",
-          "architecture": "{{ event['source_ami_architecture'] or 'x86_64'}}"
+          "root-device-type": "ebs",
+          "architecture": "x86_64"
         },
         "owners": ["{{ event['source_ami_owner'] or '679593333241' }}"],
         "most_recent": true

--- a/dw-general-ami/generic_packer_template.json.j2
+++ b/dw-general-ami/generic_packer_template.json.j2
@@ -9,7 +9,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "{{ event['source_ami_virt_type'] or 'hvm' }}",
-          "name": "{{ event['source_ami_name'] or 'amzn-ami-hvm-*'}}",
+          "name": "amzn-ami-hvm-*",
           "root-device-type": "{{ event['source_ami_root_device_type'] or 'ebs'}}",
           "architecture": "{{ event['source_ami_architecture'] or 'x86_64'}}"
         },

--- a/dw-hardened-ami/generic_packer_template.json.j2
+++ b/dw-hardened-ami/generic_packer_template.json.j2
@@ -8,10 +8,10 @@
       "type": "amazon-ebs",
       "source_ami_filter": {
         "filters": {
-          "virtualization-type": "{{ event['source_ami_virt_type'] or 'hvm' }}",
-          "name": "{{ event['source_ami_name'] or 'amzn-ami-hvm-*'}}",
-          "root-device-type": "{{ event['source_ami_root_device_type'] or 'ebs'}}",
-          "architecture": "{{ event['source_ami_architecture'] or 'x86_64'}}"
+        "virtualization-type": "hvm",
+        "name": "amzn-ami-hvm-*",
+        "root-device-type": "ebs",
+        "architecture": "x86_64"
         },
         "owners": ["{{ event['source_ami_owner'] or '679593333241' }}"],
         "most_recent": true


### PR DESCRIPTION
Override was breaking stuff as it was using Centos, removed the override so its always the latest amazon 64bit HVM EBS