### PR TITLE
Cjc dw 2863 hardening user data scripts

### DIFF
--- a/dw-general-ami/dw-general-ami-install.sh
+++ b/dw-general-ami/dw-general-ami-install.sh
@@ -18,6 +18,8 @@ yum install -y http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-plugin-r
 
 # Configure YUM repos to point at fixed mirrors so requests through the proxy will work
 # sed -i -e 's/^mirrorlist=/#&/' -e 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
+
+sed -i -e 's/repo_upgrade: security/repo_upgrade: none/' /etc/cloud/cloud.cfg
 sudo yum-config-manager --enable epel
 sed -i -e 's/^metalink=/#&/' -e 's@^#baseurl=.*@baseurl=http://mirrors.coreix.net/fedora-epel/7/$basearch@' /etc/yum.repos.d/epel.repo
 

--- a/dw-general-ami/generic_packer_template.json.j2
+++ b/dw-general-ami/generic_packer_template.json.j2
@@ -34,7 +34,8 @@
       "snapshot_users": "{{ event['ami_users'] }}",
       {% endif %}
       "region": "{{ event['region'] }}",
-      "encrypt_boot": false
+      "encrypt_boot": false,
+      "user_data_file": "/tmp/ami-builder/dw-general-ami/user-data.txt"
     }],
     "provisioners": [
     {% if 'set_proxy' in event and event['set_proxy'] == true %}

--- a/dw-general-ami/user_data.txt
+++ b/dw-general-ami/user_data.txt
@@ -1,0 +1,2 @@
+#cloud-config
+repo_upgrade: none

--- a/dw-hardened-ami/dw-hardened-ami-install.sh
+++ b/dw-hardened-ami/dw-hardened-ami-install.sh
@@ -18,6 +18,9 @@ yum install -y http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-plugin-r
 
 # Configure YUM repos to point at fixed mirrors so requests through the proxy will work
 # sed -i -e 's/^mirrorlist=/#&/' -e 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
+
+sed -i -e 's/repo_upgrade: security/repo_upgrade: none/' /etc/cloud/cloud.cfg
+
 yum-config-manager --enable epel
 sed -i -e 's/^metalink=/#&/' -e 's@^#baseurl=.*@baseurl=http://mirrors.coreix.net/fedora-epel/7/$basearch@' /etc/yum.repos.d/epel.repo
 

--- a/dw-hardened-ami/generic_packer_template.json.j2
+++ b/dw-hardened-ami/generic_packer_template.json.j2
@@ -35,7 +35,7 @@
       {% endif %}
       "region": "{{ event['region'] }}",
       "encrypt_boot": false,
-      "user_data_file": "/tmp/ami-builder/dw-hardened-ami/user-data.sh"
+      "user_data_file": "/tmp/ami-builder/dw-hardened-ami/user-data.txt"
     }],
     "provisioners": [
     {% if 'set_proxy' in event and event['set_proxy'] == true %}

--- a/dw-hardened-ami/user_data.sh
+++ b/dw-hardened-ami/user_data.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-yum update -y

--- a/dw-hardened-ami/user_data.txt
+++ b/dw-hardened-ami/user_data.txt
@@ -1,0 +1,2 @@
+#cloud-config
+repo_upgrade: none


### PR DESCRIPTION
* Amazon Linux attempts a yum update on first boot, this holds the yum pid lock open so provision scripts cannot complete (results in ami build failure)
* Removed the auto_update on instance boot after rebundling to an AMI
