### PR TITLE
correcting location of AMI userdata file

### DIFF
--- a/dw-general-ami/generic_packer_template.json.j2
+++ b/dw-general-ami/generic_packer_template.json.j2
@@ -35,7 +35,7 @@
       {% endif %}
       "region": "{{ event['region'] }}",
       "encrypt_boot": false,
-      "user_data_file": "/tmp/ami-builder/dw-general-ami/user_data.txt"
+      "user_data_file": "user_data.txt"
     }],
     "provisioners": [
     {% if 'set_proxy' in event and event['set_proxy'] == true %}


### PR DESCRIPTION
Referring to wrong location (remote) for the userdata file, this should be local to the template when packer runs.