### PR TITLE
Force awscli package to be upgraded

### DIFF
--- a/dw-general-ami/dw-general-ami-install.sh
+++ b/dw-general-ami/dw-general-ami-install.sh
@@ -23,9 +23,8 @@ yum install -y python-devel python-pip gcc
 # Install acm cert helper
 acm_cert_helper_repo=acm-pca-cert-generator
 acm_cert_helper_version=0.11.0
-pip install boto3==1.10.15 --upgrade
 pip install https://github.com/dwp/${acm_cert_helper_repo}/releases/download/${acm_cert_helper_version}/acm_cert_helper-${acm_cert_helper_version}.tar.gz
-pip install awscli
+pip install --upgrade awscli
 
 yum remove -y gcc python-devel java-1.7.0 --remove-leaves
 


### PR DESCRIPTION
Amazon Linux 1 already contains the `awscli` package, but at an
old version.  `pip` won't install a newer version unless provided
the `--upgrade` flag