### PR TITLE
Configure YUM proxy on instance launch

### DIFF
--- a/dw-general-ami/dw-general-ami-install.sh
+++ b/dw-general-ami/dw-general-ami-install.sh
@@ -37,7 +37,7 @@ yum remove -y gcc python27-devel java-1.7.0 --remove-leaves
 
 echo "export PATH=$PATH:/usr/local/bin" >> /etc/environment
 
-cat > /usr/local/bin/set_yum_proxy.sh << SETYUMPROXY
+cat > /usr/local/bin/set_yum_proxy.sh << 'SETYUMPROXY'
 TAG_NAME="internet_proxy"
 INSTANCE_ID="`curl -s http://instance-data/latest/meta-data/instance-id`"
 REGION="`curl -s http://instance-data/latest/meta-data/placement/availability-zone | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"

--- a/dw-general-ami/dw-general-ami-install.sh
+++ b/dw-general-ami/dw-general-ami-install.sh
@@ -42,9 +42,9 @@ TAG_NAME="internet_proxy"
 INSTANCE_ID="`curl -s http://instance-data/latest/meta-data/instance-id`"
 REGION="`curl -s http://instance-data/latest/meta-data/placement/availability-zone | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
 TAG_VALUE="`aws ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=$TAG_NAME" --region $REGION --output=text | cut -f5`"
-if [ -n "${TAG_VALUE}"]; then
+if [ -n "${TAG_VALUE}" ]; then
   sed -i -e "/^enabled=/a \
-proxy=$TAG_VALUE" amzn-*.repo epel*.repo
+proxy=$TAG_VALUE" /etc/yum.repos.d/{amzn-*,epel*}.repo
 fi
 SETYUMPROXY
 chmod 0700 /usr/local/bin/set_yum_proxy.sh

--- a/dw-general-ami/generic_packer_template.json.j2
+++ b/dw-general-ami/generic_packer_template.json.j2
@@ -34,7 +34,7 @@
       "snapshot_users": "{{ event['ami_users'] }}",
       {% endif %}
       "region": "{{ event['region'] }}",
-      "encrypt_boot": false,
+      "encrypt_boot": false
     }],
     "provisioners": [
     {% if 'set_proxy' in event and event['set_proxy'] == true %}

--- a/dw-general-ami/generic_packer_template.json.j2
+++ b/dw-general-ami/generic_packer_template.json.j2
@@ -35,7 +35,6 @@
       {% endif %}
       "region": "{{ event['region'] }}",
       "encrypt_boot": false,
-      "user_data_file": "{{ event['provisioner_type_file_source'] or '/tmp/ami-builder'}}/dw-general-ami/user_data.txt"
     }],
     "provisioners": [
     {% if 'set_proxy' in event and event['set_proxy'] == true %}

--- a/dw-general-ami/user_data.txt
+++ b/dw-general-ami/user_data.txt
@@ -1,2 +1,0 @@
-#cloud-config
-repo_upgrade: none

--- a/dw-hardened-ami/generic_packer_template.json.j2
+++ b/dw-hardened-ami/generic_packer_template.json.j2
@@ -38,7 +38,6 @@
       {% endif %}
       "region": "{{ event['region'] }}",
       "encrypt_boot": false,
-      "user_data_file": "{{ event['provisioner_type_file_source'] or '/tmp/ami-builder'}}/dw-hardened-ami/user_data.txt"
     }],
     "provisioners": [
     {% if 'set_proxy' in event and event['set_proxy'] == true %}

--- a/dw-hardened-ami/generic_packer_template.json.j2
+++ b/dw-hardened-ami/generic_packer_template.json.j2
@@ -37,7 +37,7 @@
       "snapshot_users": "{{ event['ami_users'] }}",
       {% endif %}
       "region": "{{ event['region'] }}",
-      "encrypt_boot": false,
+      "encrypt_boot": false
     }],
     "provisioners": [
     {% if 'set_proxy' in event and event['set_proxy'] == true %}

--- a/dw-hardened-ami/user_data.txt
+++ b/dw-hardened-ami/user_data.txt
@@ -1,2 +1,0 @@
-#cloud-config
-repo_upgrade: none


### PR DESCRIPTION
YUM will need to have the proxy set to the correct value based on which env
the instance is being launched in (e.g. management-dev proxy for dev instances,
management proxy for production instances).

We lay down a simple(ish) shell script that retrieves the proxy endpoint
specified in the `internet_proxy` instance tag, then configure the proxy for
each individual YUM repo that needs it.

Note that we explicitly *don't* set a global YUM default proxy in /etc/yum.conf
because repositories that are laid down on the instances themselves (e.g. EMR)
could well be S3 based, and therefore *mustn't* use the proxy.