### PR TITLE
Enable YUM proxy setting to run under EMR

### DIFF
--- a/dw-general-ami/dw-general-ami-install.sh
+++ b/dw-general-ami/dw-general-ami-install.sh
@@ -51,5 +51,5 @@ chmod 0700 /usr/local/bin/set_yum_proxy.sh
 
 cat > /etc/cloud/cloud.cfg.d/15_yum_proxy.cfg << CLOUDCFG
 bootcmd:
- - [ cloud-init-per, once, /usr/local/bin/set_yum_proxy.sh ]
+ - [ cloud-init-per, once, set-yum-proxy, /usr/local/bin/set_yum_proxy.sh ]
 CLOUDCFG

--- a/dw-general-ami/dw-general-ami-install.sh
+++ b/dw-general-ami/dw-general-ami-install.sh
@@ -50,6 +50,6 @@ SETYUMPROXY
 chmod 0700 /usr/local/bin/set_yum_proxy.sh
 
 cat > /etc/cloud/cloud.cfg.d/15_yum_proxy.cfg << CLOUDCFG
-runcmd:
- - [ /usr/local/bin/set_yum_proxy.sh ]
+bootcmd:
+ - [ cloud-init-per, once, /usr/local/bin/set_yum_proxy.sh ]
 CLOUDCFG


### PR DESCRIPTION
EMR specifies a `runcmd` section in the userdata of the instances that it
spins up. That overrides any `runcmd` sections we have on disk. Instead,
specify that the yum proxy setting script be run during `bootcmd` instead.

This is much earlier than we'd generally want things like this to be run,
but the default AL1 AMI doesn't specify any `bootcmd` sections, neither does
EMR's userdata so we avoid any conflicts/overrides by doing things this way.