### PR TITLE
Add back SELinux enforcing config and umask tightening

### DIFF
--- a/dw-hardened-ami/hardening.sh
+++ b/dw-hardened-ami/hardening.sh
@@ -252,11 +252,11 @@ yum install -y \
 
 #create config file
 cat > /etc/selinux/config << EOF
-SELINUX=permissive
+SELINUX=enforcing
 SELINUXTYPE=targeted
 EOF
 
-sed -i -e 's/selinux=0/selinux=1 enforcing=0/' /boot/grub/menu.lst
+sed -i -e 's/selinux=0/selinux=1 enforcing=1/' /boot/grub/menu.lst
 
 # Create AutoRelabel
 touch /.autorelabel
@@ -748,7 +748,9 @@ usermod -g 0 root
 
 echo "#############################################################"
 echo "5.4.4 Ensure default user umask is 027 or more restrictive"
-echo "Exemption: EMR fails to bootstrap with a restrictive umask set"
+sed -i 's/^.*umask 0.*$/umask 027/' /etc/bashrc
+sed -i 's/^.*umask 0.*$/umask 027/' /etc/profile
+sed -i 's/^.*umask 0.*$/umask 027/' /etc/profile.d/*.sh
 
 echo "#############################################################"
 echo "5.4.5 Ensure default user shell timeout is 900 seconds or less"
@@ -1085,4 +1087,5 @@ sed -i 's/^weekly/daily/' /etc/logrotate.conf
 service ip6tables stop
 chkconfig ip6tables off
 
-# OpenSCAP Rule ID umask_for_daemons will fail (EMR fails to bootstrap with a restrictive umask set)
+# OpenSCAP Rule ID umask_for_daemons
+sed -i 's/^umask 022/umask 027/' /etc/init.d/functions


### PR DESCRIPTION
The generic hardened AMI should be as locked down as possible; a separate AMI
will be built specifically for EMR which will turn these back off again.