### PR TITLE
DW-3096: Turn down Cloud-Init's logging

### DIFF
--- a/dw-hardened-ami/dw-hardened-ami-install.sh
+++ b/dw-hardened-ami/dw-hardened-ami-install.sh
@@ -13,3 +13,6 @@ echo "no_proxy=$no_proxy"
 # Install Java
 yum install -y java-1.8.0-openjdk-devel jq rng-tools
 chkconfig rngd on
+
+# Turn down cloud-init logs to prevent false CloudWatch alarms regarding DEBUG logs
+sed -i s/DEBUG/INFO/ /etc/cloud/cloud.cfg.d/05_logging.cfg


### PR DESCRIPTION
CloudWatch has been configured to alert if any DEBUG level messages are
enabled in Production, because application logs at that level could leak
sensitive information.

Amazon Linux configures Cloud-Init with DEBUG logs by default, which ends up
triggering the CloudWatch alerts. Change it to INFO to avoid the false alerts.