### PR TITLE
Revert "Change General AMI volume type to io1"

### DIFF
--- a/dw-general-ami/generic_packer_template.json.j2
+++ b/dw-general-ami/generic_packer_template.json.j2
@@ -24,15 +24,6 @@
       "ssh_username": "{{ event['ssh_username'] or 'ec2-user' }}",
       "subnet_id": "{{ event['subnet_id'] }}",
       "ami_name": "dw-general-ami-{{ '{{' }} timestamp {{ '}}' }}",
-      "ami_block_device_mappings": [
-        {
-          "device_name": "/dev/xvda",
-          "volume_type": "io1",
-          "volume_size": 40,
-          "iops": 2000,
-          "delete_on_termination": true
-        }
-      ],
       {% if 'profile' in event %}
       "profile": "{{ event['profile'] }}",
       {% endif %}


### PR DESCRIPTION
Reverts dwp/ami-builder-configs#203 as EMR found to be incompatible with io1 root volumes