### PR TITLE
DW-3657 - Previous test EMR failed to start, so removing four of the eight possible causes

### DIFF
--- a/dw-hardened-ami/hardening.sh
+++ b/dw-hardened-ami/hardening.sh
@@ -738,24 +738,24 @@ echo "#############################################################"
 echo "5.4.1.5 Ensure all users last password change date is in the past"
 echo "Exemption: we have no users that we configure with passwords"
 
-echo "#############################################################"
-echo "5.4.2 Ensure system accounts are non-login"
-echo "Exemption: No users in AL1 have this, CWA adds it later but we have dealt with this upstream"
-
-echo "#############################################################"
-echo "5.4.3 Ensure default group for the root account is GID 0"
-usermod -g 0 root
-
-echo "#############################################################"
-echo "5.4.4 Ensure default user umask is 027 or more restrictive"
-sed -i 's/^.*umask 0.*$/umask 027/' /etc/bashrc
-sed -i 's/^.*umask 0.*$/umask 027/' /etc/profile
-sed -i 's/^.*umask 0.*$/umask 027/' /etc/profile.d/*.sh
-
-echo "#############################################################"
-echo "5.4.5 Ensure default user shell timeout is 900 seconds or less"
-echo 'TMOUT=600' >> /etc/bashrc
-echo 'TMOUT=600' >> /etc/profile
+#echo "#############################################################"
+#echo "5.4.2 Ensure system accounts are non-login"
+#echo "Exemption: No users in AL1 have this, CWA adds it later but we have dealt with this upstream"
+#
+#echo "#############################################################"
+#echo "5.4.3 Ensure default group for the root account is GID 0"
+#usermod -g 0 root
+#
+#echo "#############################################################"
+#echo "5.4.4 Ensure default user umask is 027 or more restrictive"
+#sed -i 's/^.*umask 0.*$/umask 027/' /etc/bashrc
+#sed -i 's/^.*umask 0.*$/umask 027/' /etc/profile
+#sed -i 's/^.*umask 0.*$/umask 027/' /etc/profile.d/*.sh
+#
+#echo "#############################################################"
+#echo "5.4.5 Ensure default user shell timeout is 900 seconds or less"
+#echo 'TMOUT=600' >> /etc/bashrc
+#echo 'TMOUT=600' >> /etc/profile
 #
 #echo "#############################################################"
 #echo "5.5 Ensure access to the su command is restricted"


### PR DESCRIPTION
Signed-off-by: Benjamin Sherwood <benjamin.sherwood@dwp.gov.uk>