### PR TITLE
Add AL2 EMR AMI

### DIFF
--- a/dw-al2-emr-ami/dw-emr-ami-install.sh
+++ b/dw-al2-emr-ami/dw-emr-ami-install.sh
@@ -8,7 +8,7 @@ cat > /etc/selinux/config << EOF
 SELINUX=permissive
 SELINUXTYPE=targeted
 EOF
-sed -i -e 's/selinux=0/selinux=1 enforcing=0/' /boot/grub/menu.lst
+#sed -i -e 's/selinux=0/selinux=1 enforcing=0/' /boot/grub/menu.lst
 
 # Relax umask settings and defaults
 sed -i 's/^.*umask 0.*$/umask 002/' /etc/bashrc

--- a/dw-al2-emr-ami/dw-emr-ami-install.sh
+++ b/dw-al2-emr-ami/dw-emr-ami-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eEu
+
+# Make changes to hardened-ami that are required for EMR to work
+
+# Change SELinux config to be permissive
+cat > /etc/selinux/config << EOF
+SELINUX=permissive
+SELINUXTYPE=targeted
+EOF
+sed -i -e 's/selinux=0/selinux=1 enforcing=0/' /boot/grub/menu.lst
+
+# Relax umask settings and defaults
+sed -i 's/^.*umask 0.*$/umask 002/' /etc/bashrc
+sed -i 's/^.*umask 0.*$/umask 002/' /etc/profile
+sed -i 's/^.*umask 0.*$/umask 002/' /etc/profile.d/*.sh
+sed -i 's/^umask 027/umask 002/' /etc/init.d/functions

--- a/dw-al2-emr-ami/generic_packer_template.json.j2
+++ b/dw-al2-emr-ami/generic_packer_template.json.j2
@@ -1,0 +1,132 @@
+{
+    "variables": {
+        "http_proxy": "{% raw %}{{ env `HTTP_PROXY` }}{% endraw %}",
+        "https_proxy": "{% raw %}{{ env `HTTPS_PROXY` }}{% endraw %}",
+        "no_proxy": "{% raw %}{{ env `NO_PROXY` }}{% endraw %}"
+    },
+    "builders": [{
+      "type": "amazon-ebs",
+      {% if 'source_ami_id' in event and event['source_ami_id']|length > 0 %}
+        "source_ami": "{{ event['source_ami_id']}}",
+      {% endif %}
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "{{ event['source_ami_virt_type'] or 'hvm' }}",
+          "name": "{{ event['source_ami_name'] or 'amzn-ami-hvm-*' }}",
+          "root-device-type": "{{ event['source_ami_root_device_type'] or 'ebs' }}",
+          "architecture": "x86_64"
+        },
+        "owners": ["{{ event['source_ami_owner'] or '137112412989' }}"],
+        "most_recent": true
+      },
+      "instance_type": "{{ event['instance_type'] or 't2.micro' }}",
+      "ssh_username": "{{ event['ssh_username'] or 'ec2-user' }}",
+      "subnet_id": "{{ event['subnet_id'] }}",
+      "ami_name": "{{ event['ami_name'] or 'hardened-ami' }}-{{ '{{' }} timestamp {{ '}}' }}",
+      {% if 'profile' in event %}
+      "profile": "{{ event['profile'] }}",
+      {% endif %}
+      {% if 'security_group_id' in event %}
+      "security_group_id": "{{ event['security_group_id'] }}",
+      {% endif %}
+      {% if 'ami_regions' in event %}
+      "ami_regions": "{{ event['ami_regions'] }}",
+      {% endif %}
+      {% if 'ami_users' in event %}
+      "ami_users": "{{ event['ami_users'] }}",
+      "snapshot_users": "{{ event['ami_users'] }}",
+      {% endif %}
+      "region": "{{ event['region'] }}",
+      {% if 'run_tags' in event %}
+      "run_tags": {{ event['run_tags']|tojson }},
+      {% endif %}
+      "encrypt_boot": false
+    }],
+    "provisioners": [
+    {% if 'set_proxy' in event and event['set_proxy'] == true %}
+        {
+          "type": "shell",
+          "inline": [
+            "sudo sh -c 'echo \"export HTTP_PROXY={% raw %}{{ user `http_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
+            "sudo sh -c 'echo \"export http_proxy={% raw %}{{ user `http_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
+            "sudo sh -c 'echo \"export HTTPS_PROXY={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
+            "sudo sh -c 'echo \"export https_proxy={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
+            "sudo sh -c 'echo \"export NO_PROXY={% raw %}{{ user `no_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
+            "sudo sh -c 'echo \"export no_proxy={% raw %}{{ user `no_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
+            "sudo sh -c 'echo \"export HTTP_PROXY={% raw %}{{ user `http_proxy` }}{% endraw %} \" >> /etc/environment'",
+            "sudo sh -c 'echo \"export http_proxy={% raw %}{{ user `http_proxy` }}{% endraw %} \" >> /etc/environment'",
+            "sudo sh -c 'echo \"export HTTPS_PROXY={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/environment'",
+            "sudo sh -c 'echo \"export https_proxy={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/environment'",
+            "sudo sh -c 'echo \"export NO_PROXY={% raw %}{{ user `no_proxy` }}{% endraw %} \" >> /etc/environment'",
+            "sudo sh -c 'echo \"export no_proxy={% raw %}{{ user `no_proxy` }}{% endraw %} \" >> /etc/environment'",
+            "sudo sh -c 'echo \"proxy={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/yum.conf'"
+          ]
+        }
+    {% else %}
+        {
+          "type": "shell",
+          "inline": [
+            "echo \"proxy settings not set\""
+          ]
+        }
+    {% endif %}
+    {% if 'provision_scripts' in event and event['provision_scripts']|length > 0 %}
+        {% for provisioner_script in event['provision_scripts'] %}
+        ,
+        {
+          "type": "shell",
+          "inline": "{{ provisioner_script }}"
+          {% if 'set_proxy' in event and event['set_proxy'] == true %}
+          ,
+          "environment_vars": [
+            "HTTP_PROXY={% raw %}{{ user `http_proxy` }}{% endraw %}",
+            "HTTPS_PROXY={% raw %}{{ user `https_proxy` }}{% endraw %}",
+            "http_proxy={% raw %}{{ user `http_proxy` }}{% endraw %}",
+            "https_proxy={% raw %}{{ user `http_proxy` }}{% endraw %}",
+            "NO_PROXY={% raw %}{{ user `no_proxy` }}{% endraw %}",
+            "no_proxy={% raw %}{{ user `no_proxy` }}{% endraw %}"
+          ]
+          {% endif %}
+        }
+      {% endfor %}
+    {% endif %}
+    {% if 'provision_script_keys' in event and event['provision_script_keys']|length > 0 %}
+        ,
+        {
+          "type": "file",
+          "source": "{{ event['provisioner_type_file_source'] or '/tmp/ami-builder'}}",
+          "destination": "{{ event['provisioner_type_file_destination'] or '/tmp'}}"
+        }
+        {% for provisioner in event['provision_script_keys'] %}
+        ,
+        {
+          "type": "shell",
+          "script": "{{download_dir}}/{{ provisioner }}",
+          "execute_command": "sudo -E sh -eux -c '{% raw %}{{ .Path }}{% endraw %}'"
+          {% if 'set_proxy' in event and event['set_proxy'] == true %}
+          ,
+          "environment_vars": [
+            "HTTP_PROXY={% raw %}{{ user `http_proxy` }}{% endraw %}",
+            "HTTPS_PROXY={% raw %}{{ user `https_proxy` }}{% endraw %}",
+            "http_proxy={% raw %}{{ user `http_proxy` }}{% endraw %}",
+            "https_proxy={% raw %}{{ user `http_proxy` }}{% endraw %}",
+            "NO_PROXY={% raw %}{{ user `no_proxy` }}{% endraw %}",
+            "no_proxy={% raw %}{{ user `no_proxy` }}{% endraw %}"
+          ]
+          {% endif %}
+        }
+        {% endfor %}
+    {% endif %}
+    {% if 'set_proxy' in event and event['set_proxy'] == true %}
+        ,
+        {
+          "type": "shell",
+          "inline": [
+            "sudo sh -c 'sed -i \"/^proxy/d\" /etc/yum.conf'",
+            "sudo sh -c '> /etc/environment'",
+            "sudo sh -c 'rm -fr /etc/profile.d/http_proxy.sh'"
+          ]
+        }
+    {% endif %}
+    ]
+}


### PR DESCRIPTION
Tested with EMR 5.30.1
An EMR cluster using this AMI will require a custom bootstrap action to start the SSM agent as Amazon-provided Systemd unit named "setup-devices" fails to do so. Bootstrap action example:

```
#!/bin/bash  
sudo /bin/systemctl start amazon-ssm-agent
```