### PR TITLE
Templating for Concourse version to be controlled by the pipeline

### DIFF
--- a/dw-al2-concourse-ami/dw-concourse-ami-install.sh
+++ b/dw-al2-concourse-ami/dw-concourse-ami-install.sh
@@ -8,6 +8,7 @@ echo "http_proxy=$http_proxy"
 echo "https_proxy=$https_proxy"
 echo "NO_PROXY=$NO_PROXY"
 echo "no_proxy=$no_proxy"
+echo "CONCOURSE_VERSION=$CONCOURSE_VERSION"
 
 # Make changes to hardened-ami that are required for Concourse to work
 
@@ -24,8 +25,8 @@ sed -i 's/^.*umask 0.*$/umask 002/' /etc/profile.d/*.sh
 sed -i 's/^umask 027/umask 002/' /etc/init.d/functions
 
 # Download and Install Concourse
-concourse_version=6.4.1
-concourse_tarball="concourse-$concourse_version-linux-amd64.tgz"
-curl -s -L -O https://github.com/concourse/concourse/releases/download/v$concourse_version/$concourse_tarball
-tar -xzf $concourse_tarball -C /usr/local
-rm $concourse_tarball
+CONCOURSE_VERSION=$CONCOURSE_VERSION
+CONCOURSE_TARBALL="concourse-$CONCOURSE_VERSION-linux-amd64.tgz"
+curl -s -L -O https://github.com/concourse/concourse/releases/download/v$CONCOURSE_VERSION/$CONCOURSE_TARBALL
+tar -xzf $CONCOURSE_TARBALL -C /usr/local
+rm $CONCOURSE_TARBALL

--- a/dw-al2-concourse-ami/generic_packer_template.json.j2
+++ b/dw-al2-concourse-ami/generic_packer_template.json.j2
@@ -40,7 +40,10 @@
       {% if 'run_tags' in event %}
       "run_tags": {{ event['run_tags']|tojson }},
       {% endif %}
-      "encrypt_boot": false
+      "encrypt_boot": false,
+      "tags": {
+        "Concourse_Version": "{{ event['concourse_version'] }}"
+      }
     }],
     "provisioners": [
     {% if 'set_proxy' in event and event['set_proxy'] == true %}
@@ -67,6 +70,22 @@
           "type": "shell",
           "inline": [
             "echo \"proxy settings not set\""
+          ]
+        }
+    {% endif %}
+    {% if 'concourse_version' in event and event['concourse_version']|length > 0 %}
+        ,
+        {
+          "type": "shell",
+          "inline": [
+            "sudo sh -c 'echo \"export CONCOURSE_VERSION={{ event['concourse_version'] }}\" >> /etc/environment'"
+          ]
+        }
+    {% else %}
+        {
+          "type": "shell",
+          "inline": [
+            "echo \"concourse version not set\""
           ]
         }
     {% endif %}


### PR DESCRIPTION
This improves the templating, allowing the Concourse version to be controlled by the pipeline that builds the Concourse AMI.