### PR TITLE
Don't set proxy in system-wide environment

### DIFF
--- a/ci/infra/meta.yml
+++ b/ci/infra/meta.yml
@@ -155,7 +155,7 @@ meta:
           type: docker-image
           source:
             repository: dwpdigital/packer
-            tag: 0.0.1
+            tag: 0.0.2
         inputs:
           - name: packer-config
         params:

--- a/generic_packer_template.json.j2
+++ b/generic_packer_template.json.j2
@@ -58,33 +58,6 @@
           ]
         },
     {% endif %}
-    {% if 'set_proxy' in event and event['set_proxy'] == true %}
-        {
-          "type": "shell",
-          "inline": [
-            "sudo sh -c 'echo \"export HTTP_PROXY={% raw %}{{ user `http_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
-            "sudo sh -c 'echo \"export http_proxy={% raw %}{{ user `http_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
-            "sudo sh -c 'echo \"export HTTPS_PROXY={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
-            "sudo sh -c 'echo \"export https_proxy={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
-            "sudo sh -c 'echo \"export NO_PROXY={% raw %}{{ user `no_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
-            "sudo sh -c 'echo \"export no_proxy={% raw %}{{ user `no_proxy` }}{% endraw %} \" >> /etc/profile.d/http_proxy.sh'",
-            "sudo sh -c 'echo \"export HTTP_PROXY={% raw %}{{ user `http_proxy` }}{% endraw %} \" >> /etc/environment'",
-            "sudo sh -c 'echo \"export http_proxy={% raw %}{{ user `http_proxy` }}{% endraw %} \" >> /etc/environment'",
-            "sudo sh -c 'echo \"export HTTPS_PROXY={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/environment'",
-            "sudo sh -c 'echo \"export https_proxy={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/environment'",
-            "sudo sh -c 'echo \"export NO_PROXY={% raw %}{{ user `no_proxy` }}{% endraw %} \" >> /etc/environment'",
-            "sudo sh -c 'echo \"export no_proxy={% raw %}{{ user `no_proxy` }}{% endraw %} \" >> /etc/environment'",
-            "sudo sh -c 'echo \"proxy={% raw %}{{ user `https_proxy` }}{% endraw %} \" >> /etc/yum.conf'"
-          ]
-        }
-    {% else %}
-        {
-          "type": "shell",
-          "inline": [
-            "echo \"proxy settings not set\""
-          ]
-        }
-    {% endif %}
     {% if 'concourse_version' in event and event['concourse_version']|length > 0 %}
         ,
         {


### PR DESCRIPTION
This breaks things when instances are launched because they'll not
be able to reach the proxy endpoint that Packer can when building.