### PR TITLE
Add template as resource, fix template for multiple scripts

### DIFF
--- a/ci/infra/jobs/build_amis/dw-al2-base-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-base-ami.yml
@@ -4,6 +4,11 @@ resources:
     source:
       paths:
         - dw-al2-base-ami/*
+
+  - name: dw-al2-base-ami-template
+    .: (( inject meta.resources.ami-builder-configs ))
+    source:
+      paths:
         - generic_packer_template.json.j2
 
   - name: dw-al2-base-ami-pr
@@ -11,12 +16,19 @@ resources:
     source:
       paths:
         - dw-al2-base-ami/*
+
+  - name: dw-al2-base-ami-template-pr
+    .: (( inject meta.resources.ami-builder-configs ))
+    source:
+      paths:
         - generic_packer_template.json.j2
 
 jobs:
   - name: dw-al2-base-ami
     plan:
       - get: dw-al2-base-ami-config
+        trigger: true
+      - get: dw-al2-base-ami-template
         trigger: true
       - .: (( inject meta.plan.generate-manifest ))
         config:
@@ -27,6 +39,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-base-ami-config
+          source_template: dw-al2-base-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           inputs:
@@ -36,6 +49,9 @@ jobs:
     max_in_flight: 1
     plan:
       - get: dw-al2-base-ami-pr
+        trigger: true
+        version: every
+      - get: dw-al2-base-ami-template-pr
         trigger: true
         version: every
       - put: dw-al2-base-ami-pr
@@ -52,6 +68,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-base-ami-pr
+          source_template: dw-al2-base-ami-template-pr
       - .: (( inject meta.plan.build-ami ))
         config:
           params:

--- a/ci/infra/jobs/build_amis/dw-al2-concourse-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-concourse-ami.yml
@@ -5,6 +5,12 @@ resources:
       paths:
         - dw-al2-concourse-ami/*
 
+  - name: dw-al2-concourse-ami-template
+    .: (( inject meta.resources.ami-builder-configs ))
+    source:
+      paths:
+        - generic_packer_template.json.j2
+
   - name: dw-al2-concourse-ami-pr
     .: (( inject meta.resources.ami-builder-configs-pr ))
     source:
@@ -16,6 +22,8 @@ jobs:
     plan:
       - get: dw-al2-concourse-ami-config
         trigger: true
+      - get: dw-al2-concourse-ami-template
+        trigger: false
       - .: (( inject meta.plan.get-al2-hardened-ami ))
       - .: (( inject meta.plan.generate-manifest ))
         input_mapping:
@@ -31,6 +39,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-concourse-ami-config
+          source_template: dw-al2-concourse-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           inputs:
@@ -42,6 +51,8 @@ jobs:
       - get: dw-al2-concourse-ami-pr
         trigger: true
         version: every
+      - get: dw-al2-concourse-ami-template
+        trigger: false
       - put: dw-al2-concourse-ami-pr
         params:
           path: dw-al2-concourse-ami-pr
@@ -63,6 +74,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-concourse-ami-pr
+          source_template: dw-al2-concourse-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           params:

--- a/ci/infra/jobs/build_amis/dw-al2-ecs-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-ecs-ami.yml
@@ -5,6 +5,12 @@ resources:
       paths:
         - dw-al2-ecs-ami/*
 
+  - name: dw-al2-ecs-ami-template
+    .: (( inject meta.resources.ami-builder-configs ))
+    source:
+      paths:
+        - generic_packer_template.json.j2
+
   - name: dw-al2-ecs-ami-pr
     .: (( inject meta.resources.ami-builder-configs-pr ))
     source:
@@ -16,6 +22,8 @@ jobs:
     plan:
       - get: dw-al2-ecs-ami-config
         trigger: true
+      - get: dw-al2-ecs-ami-template
+        trigger: false
       - .: (( inject meta.plan.get-al2-hardened-ami ))
       - .: (( inject meta.plan.generate-manifest ))
         input_mapping:
@@ -30,6 +38,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-ecs-ami-config
+          source_template: dw-al2-ecs-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           inputs:
@@ -41,6 +50,8 @@ jobs:
       - get: dw-al2-ecs-ami-pr
         trigger: true
         version: every
+      - get: dw-al2-ecs-ami-template
+        trigger: false
       - put: dw-al2-ecs-ami-pr
         params:
           path: dw-al2-ecs-ami-pr
@@ -61,6 +72,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-ecs-ami-pr
+          source_template: dw-al2-ecs-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           params:

--- a/ci/infra/jobs/build_amis/dw-al2-emr-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-emr-ami.yml
@@ -5,6 +5,12 @@ resources:
       paths:
         - dw-al2-emr-ami/*
 
+  - name: dw-al2-emr-ami-template
+    .: (( inject meta.resources.ami-builder-configs ))
+    source:
+      paths:
+        - generic_packer_template.json.j2
+
   - name: dw-al2-emr-ami-pr
     .: (( inject meta.resources.ami-builder-configs-pr ))
     source:
@@ -16,6 +22,8 @@ jobs:
     plan:
       - get: dw-al2-emr-ami-config
         trigger: true
+      - get: dw-al2-emr-ami-template
+        trigger: false
       - .: (( inject meta.plan.get-al2-hardened-ami ))
       - .: (( inject meta.plan.generate-manifest ))
         input_mapping:
@@ -30,6 +38,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-emr-ami-config
+          source_template: dw-al2-emr-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           inputs:
@@ -41,6 +50,8 @@ jobs:
       - get: dw-al2-emr-ami-pr
         trigger: true
         version: every
+      - get: dw-al2-emr-ami-template
+        trigger: false
       - put: dw-al2-emr-ami-pr
         params:
           path: dw-al2-emr-ami-pr
@@ -61,6 +72,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-emr-ami-pr
+          source_template: dw-al2-emr-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           params:

--- a/ci/infra/jobs/build_amis/dw-al2-hardened-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-hardened-ami.yml
@@ -5,6 +5,12 @@ resources:
       paths:
         - dw-al2-hardened-ami/*
 
+  - name: dw-al2-hardened-ami-template
+    .: (( inject meta.resources.ami-builder-configs ))
+    source:
+      paths:
+        - generic_packer_template.json.j2
+
   - name: dw-al2-hardened-ami-pr
     .: (( inject meta.resources.ami-builder-configs-pr ))
     source:
@@ -16,6 +22,8 @@ jobs:
     plan:
       - get: dw-al2-hardened-ami-config
         trigger: true
+      - get: dw-al2-hardened-ami-template
+        trigger: false
       - get: dw-al2-base-ami
         trigger: true
       - .: (( inject meta.plan.generate-manifest ))
@@ -31,6 +39,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-hardened-ami-config
+          source_template: dw-al2-hardened-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           inputs:
@@ -42,6 +51,8 @@ jobs:
       - get: dw-al2-hardened-ami-pr
         trigger: true
         version: every
+      - get: dw-al2-hardened-ami-template
+        trigger: false
       - get: dw-al2-base-ami
       - put: dw-al2-hardened-ami-pr
         params:
@@ -61,6 +72,7 @@ jobs:
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
           source_config: dw-al2-hardened-ami-pr
+          source_template: dw-al2-hardened-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:
           params:

--- a/ci/infra/meta.yml
+++ b/ci/infra/meta.yml
@@ -137,12 +137,16 @@ meta:
             - -exc
             - |
               pwd
+              cp ../source_template/generic_packer_template.json.j2 .
               cp ../manifest/manifest.json .
               python3 bootstrap_packer.py
               cp packer.json ../packer-config
         inputs:
           - name: manifest
           - name: source_config
+          - name: source_template
+            optional: true
+
         outputs:
           - name: packer-config
 

--- a/generic_packer_template.json.j2
+++ b/generic_packer_template.json.j2
@@ -58,8 +58,9 @@
           "type": "file",
           "source": "{{ event['provisioner_type_file_source'] or '/tmp/ami-builder'}}",
           "destination": "{{ event['provisioner_type_file_destination'] or '/tmp/'}}"
-        },
+        }
         {% for provisioner in event['provision_script_keys'] %}
+        ,
         {
           "type": "shell",
           "script": "{{ provisioner }}",


### PR DESCRIPTION
In order for each AMI to build correctly, they need the latest version template.  But changes to the template should only trigger builds on the base image.

This way seemed most sane to me.