### PR TITLE
install s3fs

### DIFF
--- a/dw-al2-ecs-ami/dw-ecs-ami-install.sh
+++ b/dw-al2-ecs-ami/dw-ecs-ami-install.sh
@@ -19,4 +19,4 @@ systemctl enable --now ecs
 amazon-linux-extras install -y epel
 rpm --import https://download.sysdig.com/DRAIOS-GPG-KEY.public
 curl -s -o /etc/yum.repos.d/draios.repo https://download.sysdig.com/stable/rpm/draios.repo
-yum install -y sysdig
+yum install -y sysdig s3fs-fuse


### PR DESCRIPTION
In order to be able to mount S3 as a volume, we need to install `s3fs-fuse`