### PR TITLE
Ensure latest ecs agent

### DIFF
--- a/dw-al2-ecs-ami/dw-ecs-ami-install.sh
+++ b/dw-al2-ecs-ami/dw-ecs-ami-install.sh
@@ -14,6 +14,9 @@ amazon-linux-extras disable docker
 amazon-linux-extras install -y ecs
 systemctl enable --now ecs
 
+# Ensure latest agent is installed
+yum update -y ecs-init
+
 # Install Sysdig
 
 amazon-linux-extras install -y epel

--- a/dw-al2-ecs-ami/dw-ecs-ami-install.sh
+++ b/dw-al2-ecs-ami/dw-ecs-ami-install.sh
@@ -9,14 +9,19 @@ SELINUX=permissive
 SELINUXTYPE=targeted
 EOF
 
+echo "Ensure latest docker is installed"
+yum update -y docker
+systemctl restart docker
+
 # Download and Install ECS Agent
 amazon-linux-extras disable docker
 amazon-linux-extras install -y ecs
 systemctl enable --now ecs
 
+
 # Ensure latest agent is installed
 echo "Ensure latest agent is installed"
-yum update -y ecs-init
+yum update -y ecs-int
 
 # Install Sysdig
 

--- a/dw-al2-ecs-ami/dw-ecs-ami-install.sh
+++ b/dw-al2-ecs-ami/dw-ecs-ami-install.sh
@@ -10,8 +10,7 @@ SELINUXTYPE=targeted
 EOF
 
 echo "Ensure latest docker is installed"
-yum update -y docker
-systemctl restart docker
+yum install -y docker
 
 # Download and Install ECS Agent
 amazon-linux-extras disable docker

--- a/dw-al2-ecs-ami/dw-ecs-ami-install.sh
+++ b/dw-al2-ecs-ami/dw-ecs-ami-install.sh
@@ -15,6 +15,7 @@ amazon-linux-extras install -y ecs
 systemctl enable --now ecs
 
 # Ensure latest agent is installed
+echo "Ensure latest agent is installed"
 yum update -y ecs-init
 
 # Install Sysdig

--- a/dw-al2-ecs-ami/dw-ecs-ami-install.sh
+++ b/dw-al2-ecs-ami/dw-ecs-ami-install.sh
@@ -9,18 +9,11 @@ SELINUX=permissive
 SELINUXTYPE=targeted
 EOF
 
-echo "Ensure latest docker is installed"
-yum install -y docker
-
 # Download and Install ECS Agent
 amazon-linux-extras disable docker
-amazon-linux-extras install -y ecs
+amazon-linux-extras enable -y ecs
+yum install -y ecs-int
 systemctl enable --now ecs
-
-
-# Ensure latest agent is installed
-echo "Ensure latest agent is installed"
-yum update -y ecs-int
 
 # Install Sysdig
 


### PR DESCRIPTION
We're constantly behind in agent versions.  This should keep us at least as up to date as the AMI offers.