### PR TITLE
nonono ulimit

### DIFF
--- a/dw-al2-emr-ami/dw-emr-ami-install.sh
+++ b/dw-al2-emr-ami/dw-emr-ami-install.sh
@@ -15,10 +15,3 @@ sed -i 's/^.*umask 0.*$/umask 002/' /etc/bashrc
 sed -i 's/^.*umask 0.*$/umask 002/' /etc/profile
 sed -i 's/^.*umask 0.*$/umask 002/' /etc/profile.d/*.sh
 sed -i 's/^umask 027/umask 002/' /etc/init.d/functions
-
-cat > /etc/security/limits.d/nofile.conf << EOF
-*  soft  nofile unlimited
-*  hard  nofile unlimited
-EOF
-
-chmod 0644 /etc/security/limits.d/nofile.conf


### PR DESCRIPTION
Don't need to set this the default of `65536` is "enough" according to AWS.