### PR TITLE
collates python packages into single file

### DIFF
--- a/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
@@ -81,7 +81,7 @@ jobs:
         config:
           params:
             AMI_NAME: pr-dw-al2-analytical-env-emr-ami
-            SOURCE_AMI_NAME: dw-al2-hardened-ami-*
+            SOURCE_AMI_NAME: dw-al2-base-ami-*
             SOURCE_AMI_OWNER: ((aws_account.management))
             AMI_USERS: ((aws_account.development))
             PROVISION_SCRIPT_KEYS: '["dw-al2-analytical-env-emr-ami-pr/dw-al2-analytical-env-emr-ami/dw-al2-analytical-env-emr-ami-install.sh"]'

--- a/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
@@ -20,6 +20,7 @@ jobs:
             PROVISIONER_TYPE_FILE_SOURCE: "dw-al2-analytical-env-emr-ami-config/dw-al2-analytical-env-emr-ami/"
       - .: (( inject meta.plan.packer-bootstrap ))
         input_mapping:
+          source_config: dw-al2-analytical-env-emr-ami-config
           source_template: dw-al2-base-ami-template
       - .: (( inject meta.plan.build-ami ))
         config:

--- a/dw-al2-analytical-env-emr-ami/dw-al2-analytical-env-emr-ami-install.sh
+++ b/dw-al2-analytical-env-emr-ami/dw-al2-analytical-env-emr-ami-install.sh
@@ -28,23 +28,26 @@ sed -i 's/^umask 027/umask 002/' /etc/init.d/functions
 # building pandas from source requires installing a C compiler so just get a binary.
 cat <<EOF > /tmp/py_requirements.txt
 --only-binary=:pandas:
+dfply==0.3.3
+dplython==0.0.7
+fuzzywuzzy==0.18.0
+kaleido==0.2.1
+keras==2.4.3
 nltk==3.6.1
-yake==0.4.7
-spark-nlp==3.0.1
+numpy==1.17.3
+openpyxl==3.0.7
+pandas==1.3.0
+PyDriller==2.0
+python-docx==0.8.11
+python-Levenshtein==0.12.2
 scikit-learn==0.24.1
 scikit-spark==0.4.0
-torch==1.8.1
-keras==2.4.3
 scipy==1.6.2
-pandas==1.3.0
-numpy==1.17.3
 seaborn==0.11.1
+spark-nlp==3.0.1
 statsmodels==0.12.2
-kaleido==0.2.1
-fuzzywuzzy==0.18.0
-openpyxl==3.0.7
-python-docx==0.8.11
-# python-Levenshtein==0.12.2 - issue installing here
+torch==1.8.1
+yake==0.4.7
 EOF
 
 sudo -E pip3 install --upgrade pip setuptools

--- a/dw-al2-analytical-env-emr-ami/dw-al2-analytical-env-emr-ami-install.sh
+++ b/dw-al2-analytical-env-emr-ami/dw-al2-analytical-env-emr-ami-install.sh
@@ -39,7 +39,6 @@ openpyxl==3.0.7
 pandas==1.3.0
 PyDriller==2.0
 python-docx==0.8.11
-python-Levenshtein==0.12.2
 scikit-learn==0.24.1
 scikit-spark==0.4.0
 scipy==1.6.2
@@ -48,6 +47,7 @@ spark-nlp==3.0.1
 statsmodels==0.12.2
 torch==1.8.1
 yake==0.4.7
+# python-Levenshtein==0.12.2 - issue installing here
 EOF
 
 sudo -E pip3 install --upgrade pip setuptools


### PR DESCRIPTION
oddly the analytical-env emr uses [this script](https://github.com/dwp/aws-analytical-env/blob/master/terraform/modules/emr/templates/emr/py_pckgs_install.sh) as bootstrap action which installs mostly same pkgs apart from below difference -
`
# new pkgs
dfply==0.3.3
dplython==0.0.7
PyDriller==2.0

# diff version
pandas==1.2.5

so, best is to put them into a single place instead. 