### PR TITLE
builds analytical-env ami using tested emr-ami

### DIFF
--- a/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
@@ -72,11 +72,11 @@ jobs:
         params:
           path: dw-al2-analytical-env-emr-ami-pr
           status: pending
-      - get: base-ami-id
+      - get: emr-ami-id
         trigger: false
       - .: (( inject meta.plan.generate-manifest ))
         input_mapping:
-          source_ami: base-ami-id
+          source_ami: emr-ami-id
         config:
           params:
             AMI_NAME: pr-dw-al2-analytical-env-emr-ami

--- a/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
@@ -1,10 +1,10 @@
 jobs:
   - name: untested-dw-al2-analytical-env-emr-ami
     plan:
-      - get: emr-ami-id
+      - get: dw-al2-emr-ami
         trigger: true
         passed:
-          - validate-emr-ami
+          - release-and-test-out-of-hours
       - get: dw-al2-analytical-env-emr-ami-config
         trigger: true
       - get: dw-al2-base-ami-template
@@ -72,11 +72,11 @@ jobs:
         params:
           path: dw-al2-analytical-env-emr-ami-pr
           status: pending
-      - get: emr-ami-id
+      - get: dw-al2-emr-ami
         trigger: false
       - .: (( inject meta.plan.generate-manifest ))
         input_mapping:
-          source_ami: emr-ami-id
+          source_ami: dw-al2-emr-ami
         config:
           params:
             AMI_NAME: pr-dw-al2-analytical-env-emr-ami

--- a/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-analytical-env-emr-ami.yml
@@ -1,11 +1,10 @@
 jobs:
   - name: untested-dw-al2-analytical-env-emr-ami
     plan:
-      - get: base-ami-id
+      - get: emr-ami-id
         trigger: true
         passed:
-          - release-and-test-out-of-hours
-          - dw-al2-base-ami
+          - validate-emr-ami
       - get: dw-al2-analytical-env-emr-ami-config
         trigger: true
       - get: dw-al2-base-ami-template

--- a/ci/infra/jobs/build_amis/dw-al2-base-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-base-ami.yml
@@ -71,3 +71,36 @@ jobs:
           params:
             path: dw-al2-base-ami-pr
             status: success
+
+
+  - name: release-and-test-out-of-hours
+    max_in_flight: 1
+    plan:
+      - get: utc-7pm-trigger
+        trigger: true
+      - get: dw-al2-emr-ami
+        trigger: true
+      - get: base-ami-id
+        trigger: true
+        passed:
+          - dw-al2-base-ami
+      - get: dw-al2-untested-hardened-ami
+        trigger: false
+        passed:
+          - dw-al2-test-and-promote-hardened-ami
+      - get: dw-al2-hardened-ami
+        trigger: false
+        passed:
+          - dw-al2-test-and-promote-hardened-ami
+      - get: aws-management-infrastructure
+        trigger: false
+        passed:
+          - dw-al2-test-and-promote-hardened-ami
+      - get: aws-security-tools
+        trigger: false
+        passed:
+          - dw-al2-test-and-promote-hardened-ami
+      - get: hardened-ami-id
+        trigger: true
+        passed:
+          - dw-al2-test-and-promote-hardened-ami

--- a/ci/infra/jobs/build_amis/dw-al2-hardened-ami.yml
+++ b/ci/infra/jobs/build_amis/dw-al2-hardened-ami.yml
@@ -119,35 +119,6 @@ jobs:
       do:
         - .: (( inject meta.plan.inspector-cleanup ))
 
-  - name: release-and-test-out-of-hours
-    max_in_flight: 1
-    plan:
-      - get: utc-7pm-trigger
-        trigger: true
-      - get: base-ami-id
-        trigger: true
-        passed:
-          - dw-al2-base-ami
-      - get: dw-al2-untested-hardened-ami
-        trigger: false
-        passed:
-          - dw-al2-test-and-promote-hardened-ami
-      - get: dw-al2-hardened-ami
-        trigger: false
-        passed:
-          - dw-al2-test-and-promote-hardened-ami
-      - get: aws-management-infrastructure
-        trigger: false
-        passed:
-          - dw-al2-test-and-promote-hardened-ami
-      - get: aws-security-tools
-        trigger: false
-        passed:
-          - dw-al2-test-and-promote-hardened-ami
-      - get: hardened-ami-id
-        trigger: true
-        passed:
-          - dw-al2-test-and-promote-hardened-ami
 
   - name: dw-al2-weekly-test-hardened-ami
     max_in_flight: 1

--- a/ci/infra/resources.yml
+++ b/ci/infra/resources.yml
@@ -52,6 +52,18 @@ resources:
         state: available
         name: dw-al2-base-ami-*
 
+  - name: dw-al2-emr-ami
+    type: ami
+    check_every: 5m
+    source:
+      aws_role_arn: arn:aws:iam::((aws_account.management)):role/ci
+      region: ((dataworks.aws_region))
+      filters:
+        owner-id: ((aws_account.management))
+        is-public: false
+        state: available
+        name: dw-al2-emr-ami-*
+
   - name: dw-al2-untested-hardened-ami
     type: ami
     check_every: 5m

--- a/dw-al2-analytical-env-emr-ami/dw-al2-analytical-env-emr-ami-install.sh
+++ b/dw-al2-analytical-env-emr-ami/dw-al2-analytical-env-emr-ami-install.sh
@@ -12,19 +12,6 @@ export https_proxy=$https_proxy
 export http_proxy=$http_proxy
 export no_proxy=$no_proxy
 
-# Change SELinux config to be permissive
-cat > /etc/selinux/config << EOF
-SELINUX=permissive
-SELINUXTYPE=targeted
-EOF
-#sed -i -e 's/selinux=0/selinux=1 enforcing=0/' /boot/grub/menu.lst
-
-# Relax umask settings and defaults
-sed -i 's/^.*umask 0.*$/umask 002/' /etc/bashrc
-sed -i 's/^.*umask 0.*$/umask 002/' /etc/profile
-sed -i 's/^.*umask 0.*$/umask 002/' /etc/profile.d/*.sh
-sed -i 's/^umask 027/umask 002/' /etc/init.d/functions
-
 # building pandas from source requires installing a C compiler so just get a binary.
 sudo cat > $HOME/py_requirements.txt << EOF
 --only-binary=:pandas:


### PR DESCRIPTION
- adds a resource for tested emr ami-id
- builds `analytical-env` ami using tested emr-ami
- maps correct ami for pr job
- moves out-of-hours job into base pipeline